### PR TITLE
fix: externalize hardcoded JWT secret key

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/util/JwtUtil.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/util/JwtUtil.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -12,15 +13,22 @@ import javax.crypto.SecretKey;
 @Component
 public class JwtUtil {
 
-    private final SecretKey SECRET_KEY = Keys.hmacShaKeyFor("my-super-secret-key-1234567890123456".getBytes());
-    private final long EXPIRATION_TIME = 1000 * 60 * 60 * 10; // 10 hours
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-ms}") long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+        this.expirationMs = expirationMs;
+    }
 
     public String generateToken(String email) {
         return Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .signWith(SECRET_KEY, SignatureAlgorithm.HS256)
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -34,7 +42,7 @@ public class JwtUtil {
 
     private Claims getClaims(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(SECRET_KEY)
+                .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,11 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+# ── JWT ───────────────────────────────────────────────────────────────────────
+# Override in production via environment variable: JWT_SECRET=<your-strong-secret>
+jwt.secret=${JWT_SECRET:default-dev-secret-change-in-production-min-32-chars}
+jwt.expiration-ms=36000000
+
 # ── H2 Console (dev only) ─────────────────────────────────────────────────────
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console


### PR DESCRIPTION
## What
- Removed hardcoded secret string from `JwtUtil.java`
- Added `jwt.secret` and `jwt.expiration-ms` to `application.properties`
- `JwtUtil` now receives both values via constructor `@Value` injection
- Production override: set `JWT_SECRET` environment variable

## Why
A hardcoded secret in source code means anyone with repo read access
can sign arbitrary JWT tokens and impersonate any user.

## How to override in production
```bash
export JWT_SECRET=your-strong-random-secret-at-least-32-characters
```

Closes #2 
