### PR TITLE
feat: add password-based authentication with BCrypt

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/config/SecurityConfig.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -43,5 +45,10 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
             throws Exception {
         return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/controller/AuthController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.movinsync.shuttlemanagement.controller;
 
+import com.movinsync.shuttlemanagement.dto.LoginRequest;
 import com.movinsync.shuttlemanagement.model.Student;
 import com.movinsync.shuttlemanagement.repository.StudentRepository;
 import com.movinsync.shuttlemanagement.util.JwtUtil;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
-
 
 @RestController
 @RequestMapping("/api/auth")
@@ -15,29 +19,28 @@ public class AuthController {
 
     private final StudentRepository studentRepository;
     private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
 
-    public AuthController(StudentRepository studentRepository, JwtUtil jwtUtil) {
+    public AuthController(StudentRepository studentRepository, JwtUtil jwtUtil,
+                          PasswordEncoder passwordEncoder) {
         this.studentRepository = studentRepository;
         this.jwtUtil = jwtUtil;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @PostMapping("/login")
-    public Map<String, String> login(@RequestParam String email) {
-        System.out.println("Login request received for: " + email);
-        
-        Student student = studentRepository.findByEmail(email)
-            .orElseThrow(() -> new RuntimeException("Student not found"));
-        
-        System.out.println("Student found: " + student.getName());
-        
-        // TEMP: Replace token generation to isolate issue
-        // String token = "dummy-token";
-        String token = jwtUtil.generateToken(student.getEmail());
-        System.out.println("Token generated.");
-        
-        Map<String, String> response = new HashMap<>();
-        response.put("token", token);
-        return response;
-}
+    public ResponseEntity<Map<String, String>> login(@Valid @RequestBody LoginRequest request) {
+        Student student = studentRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new RuntimeException("Student not found"));
 
+        if (!passwordEncoder.matches(request.getPassword(), student.getPassword())) {
+            Map<String, String> error = new HashMap<>();
+            error.put("error", "Invalid credentials");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+        }
+
+        Map<String, String> response = new HashMap<>();
+        response.put("token", jwtUtil.generateToken(student.getEmail()));
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/LoginRequest.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
@@ -1,5 +1,6 @@
 package com.movinsync.shuttlemanagement.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -22,6 +23,10 @@ public class Student {
     @NotBlank(message = "Email is required")
     @Email(message = "Email must be valid")
     private String email;
+
+    @NotBlank(message = "Password is required")
+    @JsonIgnore
+    private String password;
 
     @NotNull(message = "Wallet is required")
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/movinsync/shuttlemanagement/service/StudentService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/StudentService.java
@@ -2,6 +2,7 @@ package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.model.Student;
 import com.movinsync.shuttlemanagement.repository.StudentRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,36 +11,33 @@ import java.util.List;
 public class StudentService {
 
     private final StudentRepository studentRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public StudentService(StudentRepository repo) {
+    public StudentService(StudentRepository repo, PasswordEncoder passwordEncoder) {
         this.studentRepository = repo;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public Student createStudent(Student student) {
+        student.setPassword(passwordEncoder.encode(student.getPassword()));
         return studentRepository.save(student);
     }
 
     public List<Student> getAllStudents() {
         return studentRepository.findAll();
     }
-    //admin functionality to allocate and deduct points from student wallets
 
     public void allocatePoints(Long studentId, int points) {
-    Student student = studentRepository.findById(studentId)
-            .orElseThrow(() -> new RuntimeException("Student not found"));
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new RuntimeException("Student not found"));
+        student.getWallet().setBalance(student.getWallet().getBalance() + points);
+        studentRepository.save(student);
+    }
 
-    int currentBalance = student.getWallet().getBalance();
-    student.getWallet().setBalance(currentBalance + points);
-    studentRepository.save(student);
-}
-
-public void deductPoints(Long studentId, int points) {
-    Student student = studentRepository.findById(studentId)
-            .orElseThrow(() -> new RuntimeException("Student not found"));
-
-    int currentBalance = student.getWallet().getBalance();
-    student.getWallet().setBalance(currentBalance - points);
-    studentRepository.save(student);
-}
-
+    public void deductPoints(Long studentId, int points) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new RuntimeException("Student not found"));
+        student.getWallet().setBalance(student.getWallet().getBalance() - points);
+        studentRepository.save(student);
+    }
 }


### PR DESCRIPTION
## What
- Added `password` field to `Student` entity with `@JsonIgnore` 
  (never exposed in API responses)
- `POST /api/students` now requires `password` field and stores it BCrypt-hashed
- `POST /api/auth/login` changed from `?email=` query param to 
  `{ "email": "...", "password": "..." }` request body
- Returns `401 UNAUTHORIZED` on wrong password instead of giving out tokens freely
- Added `PasswordEncoder` bean to `SecurityConfig`
- Added `LoginRequest` DTO with validation annotations

## Breaking change
`POST /api/auth/login` no longer accepts `?email=` param — use request body instead.

## Test
```json
POST /api/auth/login
{ "email": "student@uni.edu", "password": "wrongpass" }
→ 401 { "error": "Invalid credentials" }

POST /api/auth/login
{ "email": "student@uni.edu", "password": "correctpass" }
→ 200 { "token": "eyJ..." }
```

closes #4 