### PR TITLE
feat: implement role-based access control (ADMIN vs STUDENT)

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/config/SecurityConfig.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/config/SecurityConfig.java
@@ -24,18 +24,16 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(csrf -> csrf
-                        .ignoringRequestMatchers("/h2-console/**")  // Allow POSTs to H2
+                        .ignoringRequestMatchers("/h2-console/**")
                         .disable()
                 )
                 .headers(headers -> headers
-                        .frameOptions(frame -> frame.sameOrigin()) // Allow H2 console in iframe
+                        .frameOptions(frame -> frame.sameOrigin())
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/auth/**",     // ✅ Allow login/register
-                                "/h2-console/**"    // ✅ Allow H2 access
-                        ).permitAll()
-                        .anyRequest().authenticated() // ✅ All other endpoints require JWT
+                        .requestMatchers("/api/auth/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/movinsync/shuttlemanagement/controller/AuthController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
         }
 
         Map<String, String> response = new HashMap<>();
-        response.put("token", jwtUtil.generateToken(student.getEmail()));
+        response.put("token", jwtUtil.generateToken(student.getEmail(), student.getRole().name()));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/model/Role.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/Role.java
@@ -1,0 +1,6 @@
+package com.movinsync.shuttlemanagement.model;
+
+public enum Role {
+    STUDENT,
+    ADMIN
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
@@ -28,6 +28,9 @@ public class Student {
     @JsonIgnore
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.STUDENT;
+
     @NotNull(message = "Wallet is required")
     @OneToOne(cascade = CascadeType.ALL)
     private Wallet wallet;

--- a/src/main/java/com/movinsync/shuttlemanagement/util/JwtFilter.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/util/JwtFilter.java
@@ -5,13 +5,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 
 @Component
 public class JwtFilter extends OncePerRequestFilter {
@@ -35,9 +36,13 @@ public class JwtFilter extends OncePerRequestFilter {
             try {
                 if (jwtUtil.validateToken(token)) {
                     String email = jwtUtil.extractEmail(token);
+                    String role  = jwtUtil.extractRole(token);
+
+                    List<SimpleGrantedAuthority> authorities =
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
                     UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+                            new UsernamePasswordAuthenticationToken(email, null, authorities);
 
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/movinsync/shuttlemanagement/util/JwtUtil.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/util/JwtUtil.java
@@ -23,9 +23,10 @@ public class JwtUtil {
         this.expirationMs = expirationMs;
     }
 
-    public String generateToken(String email) {
+    public String generateToken(String email, String role) {
         return Jwts.builder()
                 .setSubject(email)
+                .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
@@ -34,6 +35,10 @@ public class JwtUtil {
 
     public String extractEmail(String token) {
         return getClaims(token).getSubject();
+    }
+
+    public String extractRole(String token) {
+        return getClaims(token).get("role", String.class);
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
## What
- Added `Role` enum (`STUDENT`, `ADMIN`)
- `Student` entity has `role` field defaulting to `STUDENT`
- JWT token now includes a `role` claim on login
- `JwtFilter` reads the role claim and sets it as a `ROLE_` prefixed `GrantedAuthority`
- `SecurityConfig` restricts `/api/admin/**` to `ADMIN` role only → `403` for students

## How to create an ADMIN
Directly set `role = 'ADMIN'` in the H2 console for now, or register with role field in request body.

## Test
- Login as STUDENT → call `POST /api/admin/allocate-points` → `403 FORBIDDEN`
- Login as ADMIN → same call → `200 OK`

Closes #5
