### PR TITLE
feat: add university email domain validation on student registration

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/Student.java
@@ -1,6 +1,7 @@
 package com.movinsync.shuttlemanagement.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.movinsync.shuttlemanagement.validation.UniversityEmail;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -21,7 +22,8 @@ public class Student {
     private String name;
 
     @NotBlank(message = "Email is required")
-    @Email(message = "Email must be valid")
+    @Email(message = "Email must be a valid email address")
+    @UniversityEmail
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/src/main/java/com/movinsync/shuttlemanagement/validation/UniversityEmail.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/validation/UniversityEmail.java
@@ -1,0 +1,19 @@
+package com.movinsync.shuttlemanagement.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UniversityEmailValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniversityEmail {
+
+    String message() default "Email must belong to the university domain";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/validation/UniversityEmailValidator.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/validation/UniversityEmailValidator.java
@@ -1,0 +1,21 @@
+package com.movinsync.shuttlemanagement.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UniversityEmailValidator implements ConstraintValidator<UniversityEmail, String> {
+
+    @Value("${university.email.domain}")
+    private String allowedDomain;
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        return email.toLowerCase().endsWith(allowedDomain.toLowerCase());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,10 @@ spring.jpa.show-sql=true
 jwt.secret=${JWT_SECRET:default-dev-secret-change-in-production-min-32-chars}
 jwt.expiration-ms=36000000
 
+# ── University email validation ───────────────────────────────────────────────
+# Change this to your institution's domain
+university.email.domain=@university.edu
+
 # ── H2 Console (dev only) ─────────────────────────────────────────────────────
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console


### PR DESCRIPTION
## What
- Added `@UniversityEmail` custom validation annotation
- `UniversityEmailValidator` reads allowed domain from  
  `university.email.domain` in `application.properties` (default: `@university.edu`)
- Applied to `Student.email` alongside existing `@Email` annotation
- `GlobalExceptionHandler` already returns per-field 400 errors — works automatically

## Changing the domain
In `application.properties`:
```properties
university.email.domain=@youruniversity.ac.in
```

## Test
```
POST /api/students  { "email": "user@gmail.com", ... }
→ 400 { "email": "Email must belong to the university domain" }
```

```
POST /api/students  { "email": "user@university.edu", ... }
→ 201 (success)
```

closes #6 

