### PR TITLE
feat: calculate fare server-side using Haversine distance

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
@@ -19,19 +19,17 @@ public class TripController {
     @PostMapping("/book")
     public Trip bookTrip(@RequestParam Long studentId,
                          @RequestParam Long fromStopId,
-                         @RequestParam Long toStopId,
-                         @RequestParam int fare) {
-        return tripService.bookTrip(studentId, fromStopId, toStopId, fare);
+                         @RequestParam Long toStopId) {
+        return tripService.bookTrip(studentId, fromStopId, toStopId);
     }
 
     @GetMapping("/student/{studentId}")
     public List<Trip> getStudentTrips(@PathVariable Long studentId) {
         return tripService.getTripsForStudent(studentId);
     }
-    
-    @GetMapping("/student/{studentId}/total-fare")
-public int getTotalFare(@PathVariable Long studentId) {
-    return tripService.getTotalFareSpentByStudent(studentId);
-}
 
+    @GetMapping("/student/{studentId}/total-fare")
+    public int getTotalFare(@PathVariable Long studentId) {
+        return tripService.getTotalFareSpentByStudent(studentId);
+    }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/service/FareCalculatorService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/FareCalculatorService.java
@@ -1,0 +1,40 @@
+package com.movinsync.shuttlemanagement.service;
+
+import com.movinsync.shuttlemanagement.model.Stop;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FareCalculatorService {
+
+    private static final double EARTH_RADIUS_KM = 6371.0;
+    private static final int MINIMUM_FARE = 1;
+
+    @Value("${fare.rate-per-km:2}")
+    private int ratePerKm;
+
+    /**
+     * Calculates fare based on Haversine great-circle distance between two stops.
+     * Formula: fare = max(MINIMUM_FARE, ceil(distanceKm * ratePerKm))
+     */
+    public int calculate(Stop from, Stop to) {
+        double distanceKm = haversineDistance(
+                from.getLatitude(), from.getLongitude(),
+                to.getLatitude(),   to.getLongitude()
+        );
+        int fare = (int) Math.ceil(distanceKm * ratePerKm);
+        return Math.max(fare, MINIMUM_FARE);
+    }
+
+    private double haversineDistance(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
+    }
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
@@ -13,26 +13,24 @@ public class TripService {
     private final TripRepository tripRepository;
     private final StudentRepository studentRepository;
     private final StopRepository stopRepository;
-    private final WalletRepository walletRepository; // ✅ Inject wallet repo
+    private final WalletRepository walletRepository;
+    private final FareCalculatorService fareCalculatorService;
 
-    public TripService(
-            TripRepository tripRepository,
-            StudentRepository studentRepository,
-            StopRepository stopRepository,
-            WalletRepository walletRepository) { // ✅ Add to constructor
+    public TripService(TripRepository tripRepository,
+                       StudentRepository studentRepository,
+                       StopRepository stopRepository,
+                       WalletRepository walletRepository,
+                       FareCalculatorService fareCalculatorService) {
         this.tripRepository = tripRepository;
         this.studentRepository = studentRepository;
         this.stopRepository = stopRepository;
         this.walletRepository = walletRepository;
+        this.fareCalculatorService = fareCalculatorService;
     }
 
-    public Trip bookTrip(Long studentId, Long fromStopId, Long toStopId, int fare) {
+    public Trip bookTrip(Long studentId, Long fromStopId, Long toStopId) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new RuntimeException("Student not found"));
-
-        if (student.getWallet().getBalance() < fare) {
-            throw new RuntimeException("Insufficient wallet balance");
-        }
 
         Stop from = stopRepository.findById(fromStopId)
                 .orElseThrow(() -> new RuntimeException("From Stop not found"));
@@ -40,12 +38,16 @@ public class TripService {
         Stop to = stopRepository.findById(toStopId)
                 .orElseThrow(() -> new RuntimeException("To Stop not found"));
 
-        // Deduct fare and persist wallet directly
+        int fare = fareCalculatorService.calculate(from, to);
+
+        if (student.getWallet().getBalance() < fare) {
+            throw new RuntimeException("Insufficient wallet balance");
+        }
+
         Wallet wallet = student.getWallet();
         wallet.setBalance(wallet.getBalance() - fare);
-        walletRepository.save(wallet); // ✅ Persist wallet update
+        walletRepository.save(wallet);
 
-        // Create trip
         Trip trip = new Trip();
         trip.setStudent(student);
         trip.setFromStop(from);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,10 @@ spring.jpa.show-sql=true
 jwt.secret=${JWT_SECRET:default-dev-secret-change-in-production-min-32-chars}
 jwt.expiration-ms=36000000
 
+# ── Fare calculation ──────────────────────────────────────────────────────────
+# Points charged per km of Haversine distance between stops
+fare.rate-per-km=2
+
 # ── University email validation ───────────────────────────────────────────────
 # Change this to your institution's domain
 university.email.domain=@university.edu


### PR DESCRIPTION
## What
- Removed `fare` request param from `POST /api/trips/book` — clients 
  can no longer pass `fare=0` to travel for free
- Added `FareCalculatorService` using the Haversine formula to compute 
  great-circle distance between stop coordinates
- Fare = `ceil(distanceKm × ratePerKm)`, minimum 1 point
- Rate is configurable via `fare.rate-per-km` in `application.properties`

## Breaking change
`POST /api/trips/book` no longer accepts `fare` param:

##Before
```
POST /api/trips/book?studentId=1&fromStopId=2&toStopId=3&fare=10
````

##After
```
POST /api/trips/book?studentId=1&fromStopId=2&toStopId=3
```

## Tuning the fare rate
```properties
fare.rate-per-km=2   # 2 points per km (default)
```
Closes #7

