### PR TITLE
feat: add PUT and DELETE endpoints for stop management

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/StopController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/StopController.java
@@ -3,6 +3,7 @@ package com.movinsync.shuttlemanagement.controller;
 import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.service.StopService;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,5 +26,16 @@ public class StopController {
     @GetMapping
     public List<Stop> getAllStops() {
         return stopService.getAllStops();
+    }
+
+    @PutMapping("/{id}")
+    public Stop updateStop(@PathVariable Long id, @Valid @RequestBody Stop stop) {
+        return stopService.updateStop(id, stop);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteStop(@PathVariable Long id) {
+        stopService.deleteStop(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/repository/RouteRepository.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/repository/RouteRepository.java
@@ -4,4 +4,6 @@ import com.movinsync.shuttlemanagement.model.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
+
+    boolean existsByStopsId(Long stopId);
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
@@ -1,8 +1,11 @@
 package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.model.Stop;
+import com.movinsync.shuttlemanagement.repository.RouteRepository;
 import com.movinsync.shuttlemanagement.repository.StopRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -10,9 +13,11 @@ import java.util.List;
 public class StopService {
 
     private final StopRepository stopRepository;
+    private final RouteRepository routeRepository;
 
-    public StopService(StopRepository stopRepository) {
+    public StopService(StopRepository stopRepository, RouteRepository routeRepository) {
         this.stopRepository = stopRepository;
+        this.routeRepository = routeRepository;
     }
 
     public Stop saveStop(Stop stop) {
@@ -21,5 +26,27 @@ public class StopService {
 
     public List<Stop> getAllStops() {
         return stopRepository.findAll();
+    }
+
+    public Stop updateStop(Long id, Stop updated) {
+        Stop existing = stopRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Stop not found"));
+        existing.setName(updated.getName());
+        existing.setLatitude(updated.getLatitude());
+        existing.setLongitude(updated.getLongitude());
+        return stopRepository.save(existing);
+    }
+
+    public void deleteStop(Long id) {
+        if (!stopRepository.existsById(id)) {
+            throw new RuntimeException("Stop not found");
+        }
+        if (routeRepository.existsByStopsId(id)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Stop is assigned to one or more routes and cannot be deleted"
+            );
+        }
+        stopRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## What
- `PUT /api/stops/{id}` — update name, latitude, longitude of an existing stop
- `DELETE /api/stops/{id}` — remove a stop
- Delete is blocked with `409 CONFLICT` if the stop belongs to any route
- Added `existsByStopsId(Long stopId)` query to `RouteRepository`

## Test

Update a stop
```
PUT /api/stops/1
{ "name": "New Library", "latitude": 28.61, "longitude": 77.20 }
→ 200 updated stop
```

Delete a stop not in any route
```
DELETE /api/stops/3  →  204 No Content
```

Delete a stop that's in a route
```
DELETE /api/stops/1  →  409 Conflict
{ "error": "Stop is assigned to one or more routes and cannot be deleted" }
```

Closes #8