### PR TITLE
feat: add PUT and DELETE endpoints for route management

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/RouteController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/RouteController.java
@@ -3,6 +3,7 @@ package com.movinsync.shuttlemanagement.controller;
 import com.movinsync.shuttlemanagement.model.Route;
 import com.movinsync.shuttlemanagement.service.RouteService;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,5 +26,26 @@ public class RouteController {
     @GetMapping
     public List<Route> getAllRoutes() {
         return routeService.getAllRoutes();
+    }
+
+    @PutMapping("/{id}")
+    public Route updateRoute(@PathVariable Long id, @Valid @RequestBody Route route) {
+        return routeService.updateRoute(id, route);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRoute(@PathVariable Long id) {
+        routeService.deleteRoute(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{routeId}/stops/{stopId}")
+    public Route addStop(@PathVariable Long routeId, @PathVariable Long stopId) {
+        return routeService.addStopToRoute(routeId, stopId);
+    }
+
+    @DeleteMapping("/{routeId}/stops/{stopId}")
+    public Route removeStop(@PathVariable Long routeId, @PathVariable Long stopId) {
+        return routeService.removeStopFromRoute(routeId, stopId);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/service/RouteService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/RouteService.java
@@ -1,7 +1,9 @@
 package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.model.Route;
+import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.repository.RouteRepository;
+import com.movinsync.shuttlemanagement.repository.StopRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,9 +12,11 @@ import java.util.List;
 public class RouteService {
 
     private final RouteRepository routeRepository;
+    private final StopRepository stopRepository;
 
-    public RouteService(RouteRepository routeRepository) {
+    public RouteService(RouteRepository routeRepository, StopRepository stopRepository) {
         this.routeRepository = routeRepository;
+        this.stopRepository = stopRepository;
     }
 
     public Route saveRoute(Route route) {
@@ -21,5 +25,46 @@ public class RouteService {
 
     public List<Route> getAllRoutes() {
         return routeRepository.findAll();
+    }
+
+    public Route updateRoute(Long id, Route updated) {
+        Route existing = routeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Route not found"));
+        existing.setRouteName(updated.getRouteName());
+        existing.setStops(updated.getStops());
+        return routeRepository.save(existing);
+    }
+
+    public void deleteRoute(Long id) {
+        if (!routeRepository.existsById(id)) {
+            throw new RuntimeException("Route not found");
+        }
+        routeRepository.deleteById(id);
+    }
+
+    public Route addStopToRoute(Long routeId, Long stopId) {
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RuntimeException("Route not found"));
+        Stop stop = stopRepository.findById(stopId)
+                .orElseThrow(() -> new RuntimeException("Stop not found"));
+
+        if (route.getStops().contains(stop)) {
+            throw new RuntimeException("Stop is already part of this route");
+        }
+        route.getStops().add(stop);
+        return routeRepository.save(route);
+    }
+
+    public Route removeStopFromRoute(Long routeId, Long stopId) {
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RuntimeException("Route not found"));
+        Stop stop = stopRepository.findById(stopId)
+                .orElseThrow(() -> new RuntimeException("Stop not found"));
+
+        if (route.getStops().size() <= 1) {
+            throw new RuntimeException("Route must have at least one stop");
+        }
+        route.getStops().remove(stop);
+        return routeRepository.save(route);
     }
 }


### PR DESCRIPTION
## What
- `PUT /api/routes/{id}` — update route name and full stop list
- `DELETE /api/routes/{id}` — delete a route
- `POST /api/routes/{routeId}/stops/{stopId}` — add a stop to a route
- `DELETE /api/routes/{routeId}/stops/{stopId}` — remove a stop from a route
- Removing the last stop from a route is blocked with `400`
- Duplicate stop addition is blocked with `400`

## Test

Update route name
```
PUT /api/routes/1  { "routeName": "Evening Route", "stops": [...] }  →  200
```

Delete route
```
DELETE /api/routes/2  →  204 No Content
```

Add stop to route
```
POST /api/routes/1/stops/4  →  200 updated route
```
Remove stop from route
```
DELETE /api/routes/1/stops/4  →  200 updated route
```
Try removing last stop
```
DELETE /api/routes/1/stops/1  →  400 "Route must have at least one stop"
```
Closes #9