### PR TITLE
feat: add trip cancellation with full refund within window

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
@@ -23,6 +23,12 @@ public class TripController {
         return tripService.bookTrip(studentId, fromStopId, toStopId);
     }
 
+    @DeleteMapping("/{tripId}/cancel")
+    public Trip cancelTrip(@PathVariable Long tripId,
+                           @RequestParam Long studentId) {
+        return tripService.cancelTrip(tripId, studentId);
+    }
+
     @GetMapping("/student/{studentId}")
     public List<Trip> getStudentTrips(@PathVariable Long studentId) {
         return tripService.getTripsForStudent(studentId);

--- a/src/main/java/com/movinsync/shuttlemanagement/model/Trip.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/Trip.java
@@ -24,9 +24,12 @@ public class Trip {
     @ManyToOne
     private Stop toStop;
 
-    @Column(name = "fare_used") // ✅ Match DB field used in SQL
-    private Integer  fare;
+    @Column(name = "fare_used")
+    private Integer fare;
 
-    @Column(name = "timestamp") // ✅ Match DB field used in SQL
+    @Column(name = "timestamp")
     private LocalDateTime tripTime;
+
+    @Enumerated(EnumType.STRING)
+    private TripStatus status = TripStatus.BOOKED;
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/model/TripStatus.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/model/TripStatus.java
@@ -1,0 +1,7 @@
+package com.movinsync.shuttlemanagement.model;
+
+public enum TripStatus {
+    BOOKED,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
@@ -2,9 +2,11 @@ package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.model.*;
 import com.movinsync.shuttlemanagement.repository.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
@@ -15,6 +17,9 @@ public class TripService {
     private final StopRepository stopRepository;
     private final WalletRepository walletRepository;
     private final FareCalculatorService fareCalculatorService;
+
+    @Value("${trip.cancellation.full-refund-minutes:10}")
+    private int fullRefundMinutes;
 
     public TripService(TripRepository tripRepository,
                        StudentRepository studentRepository,
@@ -54,7 +59,38 @@ public class TripService {
         trip.setToStop(to);
         trip.setFare(fare);
         trip.setTripTime(LocalDateTime.now());
+        trip.setStatus(TripStatus.BOOKED);
 
+        return tripRepository.save(trip);
+    }
+
+    public Trip cancelTrip(Long tripId, Long studentId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new RuntimeException("Trip not found"));
+
+        if (!trip.getStudent().getId().equals(studentId)) {
+            throw new RuntimeException("You can only cancel your own trips");
+        }
+
+        if (trip.getStatus() == TripStatus.CANCELLED) {
+            throw new RuntimeException("Trip is already cancelled");
+        }
+
+        if (trip.getStatus() == TripStatus.COMPLETED) {
+            throw new RuntimeException("Completed trips cannot be cancelled");
+        }
+
+        long minutesSinceBooking = ChronoUnit.MINUTES.between(trip.getTripTime(), LocalDateTime.now());
+
+        if (minutesSinceBooking <= fullRefundMinutes) {
+            // Full refund
+            Wallet wallet = trip.getStudent().getWallet();
+            wallet.setBalance(wallet.getBalance() + trip.getFare());
+            walletRepository.save(wallet);
+        }
+        // No refund if cancelled after the window — fare is forfeited
+
+        trip.setStatus(TripStatus.CANCELLED);
         return tripRepository.save(trip);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,10 @@ jwt.expiration-ms=36000000
 # Points charged per km of Haversine distance between stops
 fare.rate-per-km=2
 
+# ── Trip cancellation ─────────────────────────────────────────────────────────
+# Minutes after booking within which a full refund is granted
+trip.cancellation.full-refund-minutes=10
+
 # ── University email validation ───────────────────────────────────────────────
 # Change this to your institution's domain
 university.email.domain=@university.edu


### PR DESCRIPTION
## What
- Added `TripStatus` enum: `BOOKED`, `COMPLETED`, `CANCELLED`
- `Trip` entity now carries a `status` field (defaults to `BOOKED`)
- `DELETE /api/trips/{tripId}/cancel?studentId={id}` cancels a trip
- Full fare refunded if cancelled within `trip.cancellation.full-refund-minutes` (default 10 mins)
- No refund after the window — fare is forfeited
- Guards: only booking student can cancel, already-cancelled and completed trips blocked

## Configuring the refund window
```properties
trip.cancellation.full-refund-minutes=10
```

##Test

Cancel within 10 minutes → full refund
```
DELETE /api/trips/1/cancel?studentId=1  →  200 { "status": "CANCELLED" }
```

 Cancel after 10 minutes → no refund, still cancelled
```
DELETE /api/trips/1/cancel?studentId=1  →  200 { "status": "CANCELLED" }
```

Wrong student
```
DELETE /api/trips/1/cancel?studentId=2  →  400 "You can only cancel your own trips"
```

Already cancelled
```
DELETE /api/trips/1/cancel?studentId=1  →  400 "Trip is already cancelled"
```
Closes #10 