### PR TITLE
feat: implement bus transfer system for multi-leg journeys

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/RouteController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/RouteController.java
@@ -1,7 +1,9 @@
 package com.movinsync.shuttlemanagement.controller;
 
 import com.movinsync.shuttlemanagement.dto.RouteOptimizationResult;
+import com.movinsync.shuttlemanagement.dto.TransferResult;
 import com.movinsync.shuttlemanagement.model.Route;
+import com.movinsync.shuttlemanagement.service.BusTransferService;
 import com.movinsync.shuttlemanagement.service.RouteOptimizationService;
 import com.movinsync.shuttlemanagement.service.RouteService;
 import jakarta.validation.Valid;
@@ -16,11 +18,14 @@ public class RouteController {
 
     private final RouteService routeService;
     private final RouteOptimizationService optimizationService;
+    private final BusTransferService busTransferService;
 
     public RouteController(RouteService routeService,
-                           RouteOptimizationService optimizationService) {
+                           RouteOptimizationService optimizationService,
+                           BusTransferService busTransferService) {
         this.routeService = routeService;
         this.optimizationService = optimizationService;
+        this.busTransferService = busTransferService;
     }
 
     @PostMapping
@@ -58,5 +63,11 @@ public class RouteController {
     public RouteOptimizationResult optimizeRoute(@RequestParam Long fromStopId,
                                                   @RequestParam Long toStopId) {
         return optimizationService.findOptimalPath(fromStopId, toStopId);
+    }
+
+    @GetMapping("/transfer")
+    public TransferResult findTransfer(@RequestParam Long fromStopId,
+                                       @RequestParam Long toStopId) {
+        return busTransferService.findBestTransfer(fromStopId, toStopId);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/TransferResult.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/TransferResult.java
@@ -1,0 +1,29 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import com.movinsync.shuttlemanagement.model.Stop;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class TransferResult {
+
+    // Full ordered stop list across both legs
+    private List<Stop> fullPath;
+
+    // The stop where the passenger switches shuttle
+    private Stop transferStop;
+
+    // Route name for leg 1 (fromStop -> transferStop)
+    private String leg1Route;
+
+    // Route name for leg 2 (transferStop -> toStop)
+    private String leg2Route;
+
+    // Combined fare for the entire journey (single deduction)
+    private int totalFare;
+
+    private double totalDistanceKm;
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/BusTransferService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/BusTransferService.java
@@ -1,0 +1,167 @@
+package com.movinsync.shuttlemanagement.service;
+
+import com.movinsync.shuttlemanagement.dto.TransferResult;
+import com.movinsync.shuttlemanagement.model.Route;
+import com.movinsync.shuttlemanagement.model.Stop;
+import com.movinsync.shuttlemanagement.repository.RouteRepository;
+import com.movinsync.shuttlemanagement.repository.StopRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * Finds the best two-leg transfer journey between two stops.
+ *
+ * Strategy:
+ *   1. Find all routes containing fromStop  (leg-1 candidates)
+ *   2. Find all routes containing toStop    (leg-2 candidates)
+ *   3. For every (leg1Route, leg2Route) pair find shared stops — these are transfer points
+ *   4. Pick the transfer stop that minimises total Haversine distance
+ *
+ * Time  : O(R² × S)  — R = number of routes, S = stops per route
+ * Space : O(S)       — candidate transfer stops
+ */
+@Service
+public class BusTransferService {
+
+    private final RouteRepository routeRepository;
+    private final StopRepository stopRepository;
+    private final FareCalculatorService fareCalculatorService;
+
+    public BusTransferService(RouteRepository routeRepository,
+                               StopRepository stopRepository,
+                               FareCalculatorService fareCalculatorService) {
+        this.routeRepository = routeRepository;
+        this.stopRepository = stopRepository;
+        this.fareCalculatorService = fareCalculatorService;
+    }
+
+    public TransferResult findBestTransfer(Long fromStopId, Long toStopId) {
+        Stop from = stopRepository.findById(fromStopId)
+                .orElseThrow(() -> new RuntimeException("From Stop not found"));
+        Stop to = stopRepository.findById(toStopId)
+                .orElseThrow(() -> new RuntimeException("To Stop not found"));
+
+        List<Route> allRoutes = routeRepository.findAll();
+
+        // Routes that contain the fromStop
+        List<Route> leg1Routes = allRoutes.stream()
+                .filter(r -> containsStop(r, fromStopId))
+                .toList();
+
+        // Routes that contain the toStop
+        List<Route> leg2Routes = allRoutes.stream()
+                .filter(r -> containsStop(r, toStopId))
+                .toList();
+
+        if (leg1Routes.isEmpty()) throw new RuntimeException("No routes found from the source stop");
+        if (leg2Routes.isEmpty()) throw new RuntimeException("No routes found to the destination stop");
+
+        // Find best transfer combination
+        double bestDist = Double.MAX_VALUE;
+        Stop bestTransferStop = null;
+        Route bestLeg1Route = null;
+        Route bestLeg2Route = null;
+
+        for (Route r1 : leg1Routes) {
+            for (Route r2 : leg2Routes) {
+                if (r1.getId().equals(r2.getId())) continue; // same route = no transfer needed
+
+                // Find shared stops between r1 and r2
+                Set<Long> r1StopIds = stopIds(r1);
+                for (Stop candidate : r2.getStops()) {
+                    if (!r1StopIds.contains(candidate.getId())) continue;
+                    if (candidate.getId().equals(fromStopId)) continue;
+                    if (candidate.getId().equals(toStopId)) continue;
+
+                    double dist = haversine(from, candidate) + haversine(candidate, to);
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        bestTransferStop = candidate;
+                        bestLeg1Route = r1;
+                        bestLeg2Route = r2;
+                    }
+                }
+            }
+        }
+
+        if (bestTransferStop == null) {
+            throw new RuntimeException("No transfer route found between the selected stops");
+        }
+
+        // Build full ordered path: leg1 stops + leg2 stops (excluding duplicate transfer stop)
+        List<Stop> leg1Path = stopsOnRouteBetween(bestLeg1Route, from, bestTransferStop);
+        List<Stop> leg2Path = stopsOnRouteBetween(bestLeg2Route, bestTransferStop, to);
+
+        List<Stop> fullPath = new ArrayList<>(leg1Path);
+        fullPath.addAll(leg2Path.subList(1, leg2Path.size())); // skip duplicate transfer stop
+
+        int totalFare = calculatePathFare(fullPath);
+        double totalDistKm = Math.round(bestDist * 100.0) / 100.0;
+
+        return new TransferResult(
+                fullPath,
+                bestTransferStop,
+                bestLeg1Route.getRouteName(),
+                bestLeg2Route.getRouteName(),
+                totalFare,
+                totalDistKm
+        );
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private boolean containsStop(Route route, Long stopId) {
+        return route.getStops().stream().anyMatch(s -> s.getId().equals(stopId));
+    }
+
+    private Set<Long> stopIds(Route route) {
+        Set<Long> ids = new HashSet<>();
+        for (Stop s : route.getStops()) ids.add(s.getId());
+        return ids;
+    }
+
+    /**
+     * Returns the ordered sub-list of stops on a route between two stops (inclusive).
+     * Tries forward direction first, then reverse.
+     */
+    private List<Stop> stopsOnRouteBetween(Route route, Stop from, Stop to) {
+        List<Stop> stops = route.getStops();
+        int fromIdx = -1, toIdx = -1;
+
+        for (int i = 0; i < stops.size(); i++) {
+            if (stops.get(i).getId().equals(from.getId())) fromIdx = i;
+            if (stops.get(i).getId().equals(to.getId()))   toIdx   = i;
+        }
+
+        if (fromIdx == -1 || toIdx == -1) return List.of(from, to);
+
+        if (fromIdx <= toIdx) {
+            return new ArrayList<>(stops.subList(fromIdx, toIdx + 1));
+        } else {
+            // Reverse direction
+            List<Stop> reversed = new ArrayList<>(stops.subList(toIdx, fromIdx + 1));
+            Collections.reverse(reversed);
+            return reversed;
+        }
+    }
+
+    private int calculatePathFare(List<Stop> path) {
+        int total = 0;
+        for (int i = 0; i < path.size() - 1; i++) {
+            total += fareCalculatorService.calculate(path.get(i), path.get(i + 1));
+        }
+        return total;
+    }
+
+    private double haversine(Stop a, Stop b) {
+        final double R = 6371.0;
+        double dLat = Math.toRadians(b.getLatitude()  - a.getLatitude());
+        double dLon = Math.toRadians(b.getLongitude() - a.getLongitude());
+        double h = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(a.getLatitude()))
+                * Math.cos(Math.toRadians(b.getLatitude()))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+    }
+}


### PR DESCRIPTION
## What
- Added `BusTransferService` to find the best two-leg transfer journey
- Identifies shared stops between routes as valid transfer points
- Picks the transfer stop that minimises total distance across both legs
- `GET /api/routes/transfer?fromStopId=1&toStopId=8`
- Added `TransferResult` DTO with full path, transfer stop, route names, 
  combined fare and total distance

## Algorithm
1. Find all routes containing `fromStop` (leg-1 candidates)
2. Find all routes containing `toStop` (leg-2 candidates)
3. For each (leg1, leg2) pair find shared stops as transfer candidates
4. Pick transfer stop with minimum total Haversine distance

## Response example
```json
{
  "fullPath": [ { "name": "Dorm" }, { "name": "Main Gate" }, { "name": "Lab" } ],
  "transferStop": { "name": "Main Gate" },
  "leg1Route": "Morning Route",
  "leg2Route": "Evening Route",
  "totalFare": 8,
  "totalDistanceKm": 4.21
}
```

Closes #12 