### PR TITLE
feat: implement dynamic pricing for peak and off-peak hours

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
@@ -1,5 +1,6 @@
 package com.movinsync.shuttlemanagement.controller;
 
+import com.movinsync.shuttlemanagement.dto.BookingResult;
 import com.movinsync.shuttlemanagement.model.Trip;
 import com.movinsync.shuttlemanagement.service.TripService;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +18,9 @@ public class TripController {
     }
 
     @PostMapping("/book")
-    public Trip bookTrip(@RequestParam Long studentId,
-                         @RequestParam Long fromStopId,
-                         @RequestParam Long toStopId) {
+    public BookingResult bookTrip(@RequestParam Long studentId,
+                                  @RequestParam Long fromStopId,
+                                  @RequestParam Long toStopId) {
         return tripService.bookTrip(studentId, fromStopId, toStopId);
     }
 

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/BookingResult.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/BookingResult.java
@@ -1,0 +1,15 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import com.movinsync.shuttlemanagement.model.Trip;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class BookingResult {
+
+    private Trip trip;
+    private int  baseFare;
+    private int  finalFare;
+    private boolean peakHour;
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/FareCalculatorService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/FareCalculatorService.java
@@ -4,36 +4,76 @@ import com.movinsync.shuttlemanagement.model.Stop;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
+
+/**
+ * Calculates fare using Haversine distance with optional peak-hour surcharge.
+ *
+ * Base fare : ceil(distanceKm * ratePerKm), minimum 1
+ * Peak fare : ceil(baseFare * peakMultiplier)
+ *
+ * Peak windows (configurable):
+ *   Morning : 07:00 – 09:00
+ *   Evening : 17:00 – 19:00
+ */
 @Service
 public class FareCalculatorService {
 
     private static final double EARTH_RADIUS_KM = 6371.0;
-    private static final int MINIMUM_FARE = 1;
+    private static final int    MINIMUM_FARE    = 1;
 
     @Value("${fare.rate-per-km:2}")
     private int ratePerKm;
 
-    /**
-     * Calculates fare based on Haversine great-circle distance between two stops.
-     * Formula: fare = max(MINIMUM_FARE, ceil(distanceKm * ratePerKm))
-     */
+    @Value("${fare.peak.morning-start:7}")
+    private int morningStart;
+
+    @Value("${fare.peak.morning-end:9}")
+    private int morningEnd;
+
+    @Value("${fare.peak.evening-start:17}")
+    private int eveningStart;
+
+    @Value("${fare.peak.evening-end:19}")
+    private int eveningEnd;
+
+    @Value("${fare.peak.multiplier:1.5}")
+    private double peakMultiplier;
+
     public int calculate(Stop from, Stop to) {
+        return calculate(from, to, LocalTime.now());
+    }
+
+    /**
+     * Overload accepting an explicit time — used internally and in tests.
+     */
+    public int calculate(Stop from, Stop to, LocalTime at) {
         double distanceKm = haversineDistance(
                 from.getLatitude(), from.getLongitude(),
                 to.getLatitude(),   to.getLongitude()
         );
-        int fare = (int) Math.ceil(distanceKm * ratePerKm);
-        return Math.max(fare, MINIMUM_FARE);
+        int baseFare = (int) Math.ceil(distanceKm * ratePerKm);
+        baseFare = Math.max(baseFare, MINIMUM_FARE);
+
+        if (isPeakHour(at)) {
+            return (int) Math.ceil(baseFare * peakMultiplier);
+        }
+        return baseFare;
+    }
+
+    public boolean isPeakHour(LocalTime time) {
+        int hour = time.getHour();
+        boolean morningPeak = hour >= morningStart && hour < morningEnd;
+        boolean eveningPeak = hour >= eveningStart && hour < eveningEnd;
+        return morningPeak || eveningPeak;
     }
 
     private double haversineDistance(double lat1, double lon1, double lat2, double lon2) {
         double dLat = Math.toRadians(lat2 - lat1);
         double dLon = Math.toRadians(lon2 - lon1);
-
         double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
                 + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
                 * Math.sin(dLon / 2) * Math.sin(dLon / 2);
-
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return EARTH_RADIUS_KM * c;
     }

--- a/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
@@ -1,11 +1,13 @@
 package com.movinsync.shuttlemanagement.service;
 
+import com.movinsync.shuttlemanagement.dto.BookingResult;
 import com.movinsync.shuttlemanagement.model.*;
 import com.movinsync.shuttlemanagement.repository.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -33,7 +35,7 @@ public class TripService {
         this.fareCalculatorService = fareCalculatorService;
     }
 
-    public Trip bookTrip(Long studentId, Long fromStopId, Long toStopId) {
+    public BookingResult bookTrip(Long studentId, Long fromStopId, Long toStopId) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new RuntimeException("Student not found"));
 
@@ -43,25 +45,29 @@ public class TripService {
         Stop to = stopRepository.findById(toStopId)
                 .orElseThrow(() -> new RuntimeException("To Stop not found"));
 
-        int fare = fareCalculatorService.calculate(from, to);
+        LocalTime now     = LocalTime.now();
+        boolean isPeak    = fareCalculatorService.isPeakHour(now);
+        int baseFare      = fareCalculatorService.calculate(from, to, LocalTime.of(10, 0)); // off-peak base
+        int finalFare     = fareCalculatorService.calculate(from, to, now);
 
-        if (student.getWallet().getBalance() < fare) {
+        if (student.getWallet().getBalance() < finalFare) {
             throw new RuntimeException("Insufficient wallet balance");
         }
 
         Wallet wallet = student.getWallet();
-        wallet.setBalance(wallet.getBalance() - fare);
+        wallet.setBalance(wallet.getBalance() - finalFare);
         walletRepository.save(wallet);
 
         Trip trip = new Trip();
         trip.setStudent(student);
         trip.setFromStop(from);
         trip.setToStop(to);
-        trip.setFare(fare);
+        trip.setFare(finalFare);
         trip.setTripTime(LocalDateTime.now());
         trip.setStatus(TripStatus.BOOKED);
 
-        return tripRepository.save(trip);
+        Trip saved = tripRepository.save(trip);
+        return new BookingResult(saved, baseFare, finalFare, isPeak);
     }
 
     public Trip cancelTrip(Long tripId, Long studentId) {
@@ -71,24 +77,19 @@ public class TripService {
         if (!trip.getStudent().getId().equals(studentId)) {
             throw new RuntimeException("You can only cancel your own trips");
         }
-
         if (trip.getStatus() == TripStatus.CANCELLED) {
             throw new RuntimeException("Trip is already cancelled");
         }
-
         if (trip.getStatus() == TripStatus.COMPLETED) {
             throw new RuntimeException("Completed trips cannot be cancelled");
         }
 
         long minutesSinceBooking = ChronoUnit.MINUTES.between(trip.getTripTime(), LocalDateTime.now());
-
         if (minutesSinceBooking <= fullRefundMinutes) {
-            // Full refund
             Wallet wallet = trip.getStudent().getWallet();
             wallet.setBalance(wallet.getBalance() + trip.getFare());
             walletRepository.save(wallet);
         }
-        // No refund if cancelled after the window — fare is forfeited
 
         trip.setStatus(TripStatus.CANCELLED);
         return tripRepository.save(trip);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,12 @@ jwt.expiration-ms=36000000
 # ── Fare calculation ──────────────────────────────────────────────────────────
 # Points charged per km of Haversine distance between stops
 fare.rate-per-km=2
+# Peak hour windows (24h format). Multiplier applied during these windows.
+fare.peak.morning-start=7
+fare.peak.morning-end=9
+fare.peak.evening-start=17
+fare.peak.evening-end=19
+fare.peak.multiplier=1.5
 
 # ── Trip cancellation ─────────────────────────────────────────────────────────
 # Minutes after booking within which a full refund is granted


### PR DESCRIPTION
## What
- `FareCalculatorService` now applies a peak-hour multiplier (default `1.5x`)
- Peak windows configurable in `application.properties`:
  - Morning peak: `07:00–09:00`
  - Evening peak: `17:00–19:00`
- `POST /api/trips/book` response now includes fare breakdown via `BookingResult`:
  - `baseFare` — what the trip costs off-peak
  - `finalFare` — what was actually charged
  - `peakHour` — whether peak pricing was applied

## Configuring peak windows
```properties
fare.peak.morning-start=7
fare.peak.morning-end=9
fare.peak.evening-start=17
fare.peak.evening-end=19
fare.peak.multiplier=1.5
```
Response example (during peak)
```
{
  "trip": { "id": 1, "fare": 6, "status": "BOOKED", ... },
  "baseFare": 4,
  "finalFare": 6,
  "peakHour": true
}
```

Closes #13