### PR TITLE
feat: add nearest stop suggestion using Haversine formula

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/StopController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/StopController.java
@@ -1,5 +1,6 @@
 package com.movinsync.shuttlemanagement.controller;
 
+import com.movinsync.shuttlemanagement.dto.NearestStopResult;
 import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.service.StopService;
 import jakarta.validation.Valid;
@@ -37,5 +38,13 @@ public class StopController {
     public ResponseEntity<Void> deleteStop(@PathVariable Long id) {
         stopService.deleteStop(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/nearest")
+    public List<NearestStopResult> getNearestStops(
+            @RequestParam double lat,
+            @RequestParam double lng,
+            @RequestParam(defaultValue = "3") int limit) {
+        return stopService.findNearestStops(lat, lng, limit);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/NearestStopResult.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/NearestStopResult.java
@@ -1,0 +1,13 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import com.movinsync.shuttlemanagement.model.Stop;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NearestStopResult {
+
+    private Stop stop;
+    private double distanceMetres;
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
@@ -1,5 +1,6 @@
 package com.movinsync.shuttlemanagement.service;
 
+import com.movinsync.shuttlemanagement.dto.NearestStopResult;
 import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.repository.RouteRepository;
 import com.movinsync.shuttlemanagement.repository.StopRepository;
@@ -7,10 +8,23 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Comparator;
 import java.util.List;
 
+/**
+ * Stop management service.
+ *
+ * Nearest-stop search uses the Haversine formula to compute great-circle
+ * distance from the given coordinates to every stop, then returns the
+ * closest N sorted ascending by distance.
+ *
+ * Time  : O(n)  — single pass over all stops
+ * Space : O(n)  — result list
+ */
 @Service
 public class StopService {
+
+    private static final double EARTH_RADIUS_METRES = 6_371_000.0;
 
     private final StopRepository stopRepository;
     private final RouteRepository routeRepository;
@@ -48,5 +62,31 @@ public class StopService {
             );
         }
         stopRepository.deleteById(id);
+    }
+
+    /**
+     * Returns the {@code limit} nearest stops to the given coordinates,
+     * sorted by ascending Haversine distance in metres.
+     */
+    public List<NearestStopResult> findNearestStops(double lat, double lng, int limit) {
+        if (limit <= 0) throw new RuntimeException("Limit must be greater than 0");
+
+        return stopRepository.findAll()
+                .stream()
+                .map(stop -> new NearestStopResult(stop, haversineMetres(lat, lng,
+                        stop.getLatitude(), stop.getLongitude())))
+                .sorted(Comparator.comparingDouble(NearestStopResult::getDistanceMetres))
+                .limit(limit)
+                .toList();
+    }
+
+    private double haversineMetres(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double dist = EARTH_RADIUS_METRES * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return Math.round(dist * 100.0) / 100.0;
     }
 }


### PR DESCRIPTION
## What
- `GET /api/stops/nearest?lat=28.61&lng=77.20&limit=3`
- Computes Haversine great-circle distance from given coordinates to every stop
- Returns stops sorted ascending by distance with distance in metres
- `limit` defaults to 3, configurable per request

## Complexity
| | |
|---|---|
| Time | O(n) — single pass over all stops |
| Space | O(n) — result list |

## Response example
```json
[
  { "stop": { "id": 2, "name": "Library", ... }, "distanceMetres": 143.5 },
  { "stop": { "id": 1, "name": "Main Gate", ... }, "distanceMetres": 420.0 },
  { "stop": { "id": 4, "name": "Sports Complex", ... }, "distanceMetres": 871.2 }
]
```

Closes #14 