### PR TITLE
feat: add frequent route suggestions based on booking history

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
@@ -1,6 +1,7 @@
 package com.movinsync.shuttlemanagement.controller;
 
 import com.movinsync.shuttlemanagement.dto.BookingResult;
+import com.movinsync.shuttlemanagement.dto.FrequentRouteResult;
 import com.movinsync.shuttlemanagement.model.Trip;
 import com.movinsync.shuttlemanagement.service.TripService;
 import org.springframework.web.bind.annotation.*;
@@ -38,5 +39,12 @@ public class TripController {
     @GetMapping("/student/{studentId}/total-fare")
     public int getTotalFare(@PathVariable Long studentId) {
         return tripService.getTotalFareSpentByStudent(studentId);
+    }
+
+    @GetMapping("/student/{studentId}/frequent-routes")
+    public List<FrequentRouteResult> getFrequentRoutes(
+            @PathVariable Long studentId,
+            @RequestParam(defaultValue = "3") int limit) {
+        return tripService.getFrequentRoutes(studentId, limit);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/FrequentRouteResult.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/FrequentRouteResult.java
@@ -1,0 +1,16 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class FrequentRouteResult {
+
+    private String fromStop;
+    private String toStop;
+    private long tripCount;
+    private LocalDateTime lastBooked;
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/repository/TripRepository.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/repository/TripRepository.java
@@ -3,17 +3,27 @@ package com.movinsync.shuttlemanagement.repository;
 import com.movinsync.shuttlemanagement.model.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
+
     List<Trip> findByStudentId(Long studentId);
 
-    @Query(value = "SELECT COUNT(*) FROM trip WHERE CAST(timestamp AS DATE) = CURRENT_DATE", nativeQuery = true)
+    @Query(value = "SELECT COUNT(*) FROM trip WHERE CAST(timestamp AS DATE) = CURRENT_DATE",
+            nativeQuery = true)
     long countToday();
 
-    
-    @Query(value = "SELECT SUM(fare_used) FROM trip WHERE MONTH(timestamp) = MONTH(CURRENT_DATE) AND YEAR(timestamp) = YEAR(CURRENT_DATE)", nativeQuery = true)
+    @Query(value = "SELECT SUM(fare_used) FROM trip " +
+            "WHERE MONTH(timestamp) = MONTH(CURRENT_DATE) " +
+            "AND YEAR(timestamp) = YEAR(CURRENT_DATE)",
+            nativeQuery = true)
     Long totalFareUsedThisMonth();
 
+    @Query("SELECT t FROM Trip t " +
+            "WHERE t.student.id = :studentId " +
+            "AND t.status <> com.movinsync.shuttlemanagement.model.TripStatus.CANCELLED " +
+            "ORDER BY t.tripTime DESC")
+    List<Trip> findActiveByStudentId(@Param("studentId") Long studentId);
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
@@ -1,6 +1,7 @@
 package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.dto.BookingResult;
+import com.movinsync.shuttlemanagement.dto.FrequentRouteResult;
 import com.movinsync.shuttlemanagement.model.*;
 import com.movinsync.shuttlemanagement.repository.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +10,10 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class TripService {
@@ -104,5 +108,37 @@ public class TripService {
                 .stream()
                 .mapToInt(Trip::getFare)
                 .sum();
+    }
+
+    /**
+     * Returns top N most frequently booked (fromStop, toStop) pairs for a student,
+     * sorted descending by trip count.
+     *
+     * Time  : O(t log t) — t = student's trip count
+     * Space : O(k)       — k = distinct route pairs
+     */
+    public List<FrequentRouteResult> getFrequentRoutes(Long studentId, int limit) {
+        List<Trip> trips = tripRepository.findActiveByStudentId(studentId);
+
+        if (trips.isEmpty()) return List.of();
+
+        // Group by "fromStopName -> toStopName" key
+        Map<String, List<Trip>> grouped = trips.stream()
+                .collect(Collectors.groupingBy(t ->
+                        t.getFromStop().getName() + "|" + t.getToStop().getName()));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    List<Trip> group   = entry.getValue();
+                    String[]   parts   = entry.getKey().split("\\|");
+                    LocalDateTime last = group.stream()
+                            .map(Trip::getTripTime)
+                            .max(Comparator.naturalOrder())
+                            .orElse(null);
+                    return new FrequentRouteResult(parts[0], parts[1], group.size(), last);
+                })
+                .sorted(Comparator.comparingLong(FrequentRouteResult::getTripCount).reversed())
+                .limit(limit)
+                .toList();
     }
 }


### PR DESCRIPTION
## What
- `GET /api/trips/student/{id}/frequent-routes?limit=3`
- Groups non-cancelled trips by `(fromStop, toStop)` pair
- Returns top N pairs sorted by trip count descending
- Each entry: fromStop name, toStop name, trip count, last booked timestamp
- Returns empty list (not error) if student has no history
- Added `findActiveByStudentId` JPQL query to `TripRepository` (excludes cancelled)

## Complexity
| | |
|---|---|
| Time | O(t log t) — t = student's trip count |
| Space | O(k) — k = distinct stop pairs |

## Response example
```json
[
  { "fromStop": "Dorm A", "toStop": "Library", "tripCount": 12, "lastBooked": "2026-04-10T08:30:00" },
  { "fromStop": "Library", "toStop": "Lab Block", "tripCount": 7, "lastBooked": "2026-04-09T14:00:00" },
  { "fromStop": "Dorm A", "toStop": "Sports Complex", "tripCount": 3, "lastBooked": "2026-04-08T17:15:00" }
]
```

Closes #15 