### PR TITLE
feat: add expense report endpoint with weekly and monthly breakdown

### DIFF
--- a/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/controller/TripController.java
@@ -1,6 +1,7 @@
 package com.movinsync.shuttlemanagement.controller;
 
 import com.movinsync.shuttlemanagement.dto.BookingResult;
+import com.movinsync.shuttlemanagement.dto.ExpenseReportResult;
 import com.movinsync.shuttlemanagement.dto.FrequentRouteResult;
 import com.movinsync.shuttlemanagement.model.Trip;
 import com.movinsync.shuttlemanagement.service.TripService;
@@ -46,5 +47,12 @@ public class TripController {
             @PathVariable Long studentId,
             @RequestParam(defaultValue = "3") int limit) {
         return tripService.getFrequentRoutes(studentId, limit);
+    }
+
+    @GetMapping("/student/{studentId}/expense-report")
+    public ExpenseReportResult getExpenseReport(
+            @PathVariable Long studentId,
+            @RequestParam(defaultValue = "monthly") String period) {
+        return tripService.getExpenseReport(studentId, period);
     }
 }

--- a/src/main/java/com/movinsync/shuttlemanagement/dto/ExpenseReportResult.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/dto/ExpenseReportResult.java
@@ -1,0 +1,27 @@
+package com.movinsync.shuttlemanagement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ExpenseReportResult {
+
+    private String period;          // e.g. "2026-04" or "2026-04-06 to 2026-04-12"
+    private int totalFareSpent;
+    private long tripCount;
+    private int walletBalance;
+    private List<TripSummary> trips;
+
+    @Data
+    @AllArgsConstructor
+    public static class TripSummary {
+        private String date;
+        private String fromStop;
+        private String toStop;
+        private int fare;
+        private String status;
+    }
+}

--- a/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/TripService.java
@@ -1,14 +1,17 @@
 package com.movinsync.shuttlemanagement.service;
 
 import com.movinsync.shuttlemanagement.dto.BookingResult;
+import com.movinsync.shuttlemanagement.dto.ExpenseReportResult;
 import com.movinsync.shuttlemanagement.dto.FrequentRouteResult;
 import com.movinsync.shuttlemanagement.model.*;
 import com.movinsync.shuttlemanagement.repository.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
@@ -108,6 +111,55 @@ public class TripService {
                 .stream()
                 .mapToInt(Trip::getFare)
                 .sum();
+    }
+
+    /**
+     * Generates a weekly or monthly expense report for a student.
+     * period = "monthly" → current calendar month
+     * period = "weekly"  → last 7 days
+     */
+    public ExpenseReportResult getExpenseReport(Long studentId, String period) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new RuntimeException("Student not found"));
+
+        LocalDateTime from;
+        LocalDateTime to = LocalDateTime.now();
+        String label;
+
+        if ("weekly".equalsIgnoreCase(period)) {
+            from  = LocalDate.now().minusDays(6).atStartOfDay();
+            label = LocalDate.now().minusDays(6) + " to " + LocalDate.now();
+        } else {
+            from  = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+            label = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        }
+
+        final LocalDateTime start = from;
+
+        List<Trip> trips = tripRepository.findActiveByStudentId(studentId)
+                .stream()
+                .filter(t -> !t.getTripTime().isBefore(start) && !t.getTripTime().isAfter(to))
+                .toList();
+
+        int totalFare = trips.stream().mapToInt(Trip::getFare).sum();
+
+        List<ExpenseReportResult.TripSummary> summaries = trips.stream()
+                .map(t -> new ExpenseReportResult.TripSummary(
+                        t.getTripTime().toLocalDate().toString(),
+                        t.getFromStop().getName(),
+                        t.getToStop().getName(),
+                        t.getFare(),
+                        t.getStatus().name()
+                ))
+                .toList();
+
+        return new ExpenseReportResult(
+                label,
+                totalFare,
+                trips.size(),
+                student.getWallet().getBalance(),
+                summaries
+        );
     }
 
     /**


### PR DESCRIPTION
## What
- `GET /api/trips/student/{id}/expense-report?period=monthly`
- `GET /api/trips/student/{id}/expense-report?period=weekly`
- Monthly: current calendar month from day 1 to now
- Weekly: last 7 days
- Cancelled trips excluded from totals
- Response includes: period label, total fare, trip count, 
  current wallet balance, itemized trip list

## Response example
```json
{
  "period": "2026-04",
  "totalFareSpent": 150,
  "tripCount": 12,
  "walletBalance": 350,
  "trips": [
    { "date": "2026-04-10", "fromStop": "Dorm A", "toStop": "Library", "fare": 6, "status": "BOOKED" },
    { "date": "2026-04-09", "fromStop": "Library", "toStop": "Lab", "fare": 4, "status": "BOOKED" }
  ]
}
```
Closes #16 