### PR TITLE
feat: add Caffeine caching for routes and stops with TTL eviction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/movinsync/shuttlemanagement/ShuttleManagementApplication.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/ShuttleManagementApplication.java
@@ -2,8 +2,10 @@ package com.movinsync.shuttlemanagement;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class ShuttleManagementApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/movinsync/shuttlemanagement/service/RouteService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/RouteService.java
@@ -4,6 +4,8 @@ import com.movinsync.shuttlemanagement.model.Route;
 import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.repository.RouteRepository;
 import com.movinsync.shuttlemanagement.repository.StopRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,14 +21,17 @@ public class RouteService {
         this.stopRepository = stopRepository;
     }
 
+    @CacheEvict(value = "routes", allEntries = true)
     public Route saveRoute(Route route) {
         return routeRepository.save(route);
     }
 
+    @Cacheable("routes")
     public List<Route> getAllRoutes() {
         return routeRepository.findAll();
     }
 
+    @CacheEvict(value = "routes", allEntries = true)
     public Route updateRoute(Long id, Route updated) {
         Route existing = routeRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Route not found"));
@@ -35,6 +40,7 @@ public class RouteService {
         return routeRepository.save(existing);
     }
 
+    @CacheEvict(value = "routes", allEntries = true)
     public void deleteRoute(Long id) {
         if (!routeRepository.existsById(id)) {
             throw new RuntimeException("Route not found");
@@ -42,6 +48,7 @@ public class RouteService {
         routeRepository.deleteById(id);
     }
 
+    @CacheEvict(value = "routes", allEntries = true)
     public Route addStopToRoute(Long routeId, Long stopId) {
         Route route = routeRepository.findById(routeId)
                 .orElseThrow(() -> new RuntimeException("Route not found"));
@@ -55,6 +62,7 @@ public class RouteService {
         return routeRepository.save(route);
     }
 
+    @CacheEvict(value = "routes", allEntries = true)
     public Route removeStopFromRoute(Long routeId, Long stopId) {
         Route route = routeRepository.findById(routeId)
                 .orElseThrow(() -> new RuntimeException("Route not found"));

--- a/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
+++ b/src/main/java/com/movinsync/shuttlemanagement/service/StopService.java
@@ -4,6 +4,8 @@ import com.movinsync.shuttlemanagement.dto.NearestStopResult;
 import com.movinsync.shuttlemanagement.model.Stop;
 import com.movinsync.shuttlemanagement.repository.RouteRepository;
 import com.movinsync.shuttlemanagement.repository.StopRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -34,14 +36,17 @@ public class StopService {
         this.routeRepository = routeRepository;
     }
 
+    @CacheEvict(value = "stops", allEntries = true)
     public Stop saveStop(Stop stop) {
         return stopRepository.save(stop);
     }
 
+    @Cacheable("stops")
     public List<Stop> getAllStops() {
         return stopRepository.findAll();
     }
 
+    @CacheEvict(value = "stops", allEntries = true)
     public Stop updateStop(Long id, Stop updated) {
         Stop existing = stopRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Stop not found"));
@@ -51,6 +56,7 @@ public class StopService {
         return stopRepository.save(existing);
     }
 
+    @CacheEvict(value = "stops", allEntries = true)
     public void deleteStop(Long id) {
         if (!stopRepository.existsById(id)) {
             throw new RuntimeException("Stop not found");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,12 @@ trip.cancellation.full-refund-minutes=10
 # Change this to your institution's domain
 university.email.domain=@university.edu
 
+# ── Caching (Caffeine) ────────────────────────────────────────────────────────
+spring.cache.type=caffeine
+# TTL of 5 minutes; max 500 entries per cache region
+cache.ttl-seconds=300
+spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=${cache.ttl-seconds}s
+
 # ── H2 Console (dev only) ─────────────────────────────────────────────────────
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console


### PR DESCRIPTION
## What
Adds in-memory caching via Caffeine to reduce repeated DB reads on
hot read paths.

## Changes
- `pom.xml` — adds `spring-boot-starter-cache` + `caffeine` dependencies
- `ShuttleManagementApplication` — `@EnableCaching` activates Spring's cache proxy
- `application.properties` — `spring.cache.type=caffeine`, 500-entry max,
  5-minute TTL (`cache.ttl-seconds=300`)
- `RouteService.getAllRoutes()` — `@Cacheable("routes")`; all write
  methods (`saveRoute`, `updateRoute`, `deleteRoute`, `addStopToRoute`,
  `removeStopFromRoute`) annotated `@CacheEvict(allEntries=true)` to keep
  the cache consistent
- `StopService.getAllStops()` — `@Cacheable("stops")`; `saveStop`,
  `updateStop`, `deleteStop` annotated `@CacheEvict(allEntries=true)`

## Notes
- TTL and max size are externally configurable via `cache.ttl-seconds`
  and `spring.cache.caffeine.spec`
- `findNearestStops` is intentionally not cached — it takes dynamic
  lat/lng params so per-call caching would be counterproductive

Closes #17
