### PR TITLE
feat: add unit tests for TripService and StudentService with Mockito

### DIFF
--- a/src/test/java/com/movinsync/shuttlemanagement/service/StudentServiceTest.java
+++ b/src/test/java/com/movinsync/shuttlemanagement/service/StudentServiceTest.java
@@ -1,0 +1,109 @@
+package com.movinsync.shuttlemanagement.service;
+
+import com.movinsync.shuttlemanagement.model.Role;
+import com.movinsync.shuttlemanagement.model.Student;
+import com.movinsync.shuttlemanagement.model.Wallet;
+import com.movinsync.shuttlemanagement.repository.StudentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceTest {
+
+    @Mock private StudentRepository studentRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private StudentService studentService;
+
+    private Wallet wallet;
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        wallet  = new Wallet(1L, 200);
+        student = new Student(1L, "Bob", "bob@university.edu", "rawPassword", Role.STUDENT, wallet);
+    }
+
+    // ── createStudent ─────────────────────────────────────────────────────────
+
+    @Test
+    void createStudent_encodesPasswordBeforeSave() {
+        when(passwordEncoder.encode("rawPassword")).thenReturn("encodedPassword");
+        when(studentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Student result = studentService.createStudent(student);
+
+        assertThat(result.getPassword()).isEqualTo("encodedPassword");
+        verify(passwordEncoder).encode("rawPassword");
+        verify(studentRepository).save(student);
+    }
+
+    @Test
+    void createStudent_returnsPersistedStudent() {
+        Student persisted = new Student(42L, "Bob", "bob@university.edu", "encodedPassword", Role.STUDENT, wallet);
+        when(passwordEncoder.encode(any())).thenReturn("encodedPassword");
+        when(studentRepository.save(any())).thenReturn(persisted);
+
+        Student result = studentService.createStudent(student);
+
+        assertThat(result.getId()).isEqualTo(42L);
+    }
+
+    // ── allocatePoints ────────────────────────────────────────────────────────
+
+    @Test
+    void allocatePoints_increasesWalletBalance() {
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+
+        studentService.allocatePoints(1L, 50);
+
+        assertThat(wallet.getBalance()).isEqualTo(250);
+        verify(studentRepository).save(student);
+    }
+
+    @Test
+    void allocatePoints_studentNotFound_throwsRuntimeException() {
+        when(studentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studentService.allocatePoints(99L, 50))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Student not found");
+
+        verify(studentRepository, never()).save(any());
+    }
+
+    // ── deductPoints ──────────────────────────────────────────────────────────
+
+    @Test
+    void deductPoints_decreasesWalletBalance() {
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+
+        studentService.deductPoints(1L, 30);
+
+        assertThat(wallet.getBalance()).isEqualTo(170);
+        verify(studentRepository).save(student);
+    }
+
+    @Test
+    void deductPoints_studentNotFound_throwsRuntimeException() {
+        when(studentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studentService.deductPoints(99L, 30))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Student not found");
+
+        verify(studentRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/movinsync/shuttlemanagement/service/TripServiceTest.java
+++ b/src/test/java/com/movinsync/shuttlemanagement/service/TripServiceTest.java
@@ -1,0 +1,178 @@
+package com.movinsync.shuttlemanagement.service;
+
+import com.movinsync.shuttlemanagement.dto.BookingResult;
+import com.movinsync.shuttlemanagement.model.*;
+import com.movinsync.shuttlemanagement.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceTest {
+
+    @Mock private TripRepository tripRepository;
+    @Mock private StudentRepository studentRepository;
+    @Mock private StopRepository stopRepository;
+    @Mock private WalletRepository walletRepository;
+    @Mock private FareCalculatorService fareCalculatorService;
+
+    @InjectMocks
+    private TripService tripService;
+
+    private Student student;
+    private Wallet wallet;
+    private Stop fromStop;
+    private Stop toStop;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(tripService, "fullRefundMinutes", 10);
+        wallet   = new Wallet(1L, 100);
+        student  = new Student(1L, "Alice", "alice@university.edu", "hashed", Role.STUDENT, wallet);
+        fromStop = new Stop(1L, "Stop A", 12.9716, 77.5946);
+        toStop   = new Stop(2L, "Stop B", 12.9352, 77.6245);
+    }
+
+    // ── bookTrip ─────────────────────────────────────────────────────────────
+
+    @Test
+    void bookTrip_success_deductsWalletAndReturnsResult() {
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(stopRepository.findById(1L)).thenReturn(Optional.of(fromStop));
+        when(stopRepository.findById(2L)).thenReturn(Optional.of(toStop));
+        when(fareCalculatorService.isPeakHour(any())).thenReturn(false);
+        when(fareCalculatorService.calculate(any(), any(), any())).thenReturn(10);
+
+        Trip saved = new Trip(10L, student, fromStop, toStop, 10, LocalDateTime.now(), TripStatus.BOOKED);
+        when(tripRepository.save(any())).thenReturn(saved);
+
+        BookingResult result = tripService.bookTrip(1L, 1L, 2L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getFinalFare()).isEqualTo(10);
+        assertThat(wallet.getBalance()).isEqualTo(90);
+        verify(walletRepository).save(wallet);
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void bookTrip_peakHour_reflectsInResult() {
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(stopRepository.findById(1L)).thenReturn(Optional.of(fromStop));
+        when(stopRepository.findById(2L)).thenReturn(Optional.of(toStop));
+        when(fareCalculatorService.isPeakHour(any())).thenReturn(true);
+        when(fareCalculatorService.calculate(any(), any(), any())).thenReturn(15);
+
+        Trip saved = new Trip(10L, student, fromStop, toStop, 15, LocalDateTime.now(), TripStatus.BOOKED);
+        when(tripRepository.save(any())).thenReturn(saved);
+
+        BookingResult result = tripService.bookTrip(1L, 1L, 2L);
+
+        assertThat(result.isPeakHour()).isTrue();
+        assertThat(wallet.getBalance()).isEqualTo(85);
+    }
+
+    @Test
+    void bookTrip_insufficientBalance_throwsRuntimeException() {
+        wallet.setBalance(5);
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(stopRepository.findById(1L)).thenReturn(Optional.of(fromStop));
+        when(stopRepository.findById(2L)).thenReturn(Optional.of(toStop));
+        when(fareCalculatorService.isPeakHour(any())).thenReturn(false);
+        when(fareCalculatorService.calculate(any(), any(), any())).thenReturn(10);
+
+        assertThatThrownBy(() -> tripService.bookTrip(1L, 1L, 2L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Insufficient wallet balance");
+
+        verify(tripRepository, never()).save(any());
+    }
+
+    @Test
+    void bookTrip_studentNotFound_throwsRuntimeException() {
+        when(studentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tripService.bookTrip(99L, 1L, 2L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Student not found");
+    }
+
+    @Test
+    void bookTrip_stopNotFound_throwsRuntimeException() {
+        when(studentRepository.findById(1L)).thenReturn(Optional.of(student));
+        when(stopRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tripService.bookTrip(1L, 99L, 2L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Stop not found");
+    }
+
+    // ── cancelTrip ───────────────────────────────────────────────────────────
+
+    @Test
+    void cancelTrip_withinRefundWindow_issuesFullRefund() {
+        Trip trip = new Trip(5L, student, fromStop, toStop, 20, LocalDateTime.now().minusMinutes(3), TripStatus.BOOKED);
+        when(tripRepository.findById(5L)).thenReturn(Optional.of(trip));
+        when(tripRepository.save(trip)).thenReturn(trip);
+
+        Trip result = tripService.cancelTrip(5L, 1L);
+
+        assertThat(result.getStatus()).isEqualTo(TripStatus.CANCELLED);
+        assertThat(wallet.getBalance()).isEqualTo(120); // 100 + 20 refund
+        verify(walletRepository).save(wallet);
+    }
+
+    @Test
+    void cancelTrip_outsideRefundWindow_noRefund() {
+        Trip trip = new Trip(5L, student, fromStop, toStop, 20, LocalDateTime.now().minusMinutes(15), TripStatus.BOOKED);
+        when(tripRepository.findById(5L)).thenReturn(Optional.of(trip));
+        when(tripRepository.save(trip)).thenReturn(trip);
+
+        Trip result = tripService.cancelTrip(5L, 1L);
+
+        assertThat(result.getStatus()).isEqualTo(TripStatus.CANCELLED);
+        assertThat(wallet.getBalance()).isEqualTo(100); // unchanged
+        verify(walletRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelTrip_alreadyCancelled_throwsRuntimeException() {
+        Trip trip = new Trip(5L, student, fromStop, toStop, 20, LocalDateTime.now(), TripStatus.CANCELLED);
+        when(tripRepository.findById(5L)).thenReturn(Optional.of(trip));
+
+        assertThatThrownBy(() -> tripService.cancelTrip(5L, 1L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("already cancelled");
+    }
+
+    @Test
+    void cancelTrip_completedTrip_throwsRuntimeException() {
+        Trip trip = new Trip(5L, student, fromStop, toStop, 20, LocalDateTime.now(), TripStatus.COMPLETED);
+        when(tripRepository.findById(5L)).thenReturn(Optional.of(trip));
+
+        assertThatThrownBy(() -> tripService.cancelTrip(5L, 1L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("cannot be cancelled");
+    }
+
+    @Test
+    void cancelTrip_wrongStudent_throwsRuntimeException() {
+        Trip trip = new Trip(5L, student, fromStop, toStop, 20, LocalDateTime.now(), TripStatus.BOOKED);
+        when(tripRepository.findById(5L)).thenReturn(Optional.of(trip));
+
+        assertThatThrownBy(() -> tripService.cancelTrip(5L, 99L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("only cancel your own trips");
+    }
+}


### PR DESCRIPTION
## What
Adds pure Mockito unit tests (no Spring context) for the two core services.

## Test coverage

### TripServiceTest (10 tests)
| Test | Asserts |
|---|---|
| `bookTrip_success` | wallet debited, BookingResult returned |
| `bookTrip_peakHour` | isPeakHour=true reflected in result |
| `bookTrip_insufficientBalance` | throws, wallet/trip never saved |
| `bookTrip_studentNotFound` | throws RuntimeException |
| `bookTrip_stopNotFound` | throws RuntimeException |
| `cancelTrip_withinRefundWindow` | status=CANCELLED, wallet credited |
| `cancelTrip_outsideRefundWindow` | status=CANCELLED, wallet unchanged |
| `cancelTrip_alreadyCancelled` | throws RuntimeException |
| `cancelTrip_completedTrip` | throws RuntimeException |
| `cancelTrip_wrongStudent` | throws RuntimeException |

### StudentServiceTest (6 tests)
| Test | Asserts |
|---|---|
| `createStudent_encodesPassword` | BCrypt encode called before save |
| `createStudent_returnsPersistedStudent` | returned ID matches saved entity |
| `allocatePoints_increasesBalance` | wallet balance += points |
| `allocatePoints_studentNotFound` | throws, save never called |
| `deductPoints_decreasesBalance` | wallet balance -= points |
| `deductPoints_studentNotFound` | throws, save never called |

Closes #20
