### PR TITLE
feat: add integration tests for full booking flow with SpringBootTest

### DIFF
--- a/src/test/java/com/movinsync/shuttlemanagement/BookingFlowIntegrationTest.java
+++ b/src/test/java/com/movinsync/shuttlemanagement/BookingFlowIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.movinsync.shuttlemanagement;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.movinsync.shuttlemanagement.model.*;
+import com.movinsync.shuttlemanagement.repository.*;
+import com.movinsync.shuttlemanagement.util.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BookingFlowIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private StudentRepository studentRepository;
+    @Autowired private StopRepository stopRepository;
+    @Autowired private TripRepository tripRepository;
+    @Autowired private WalletRepository walletRepository;
+    @Autowired private JwtUtil jwtUtil;
+    @Autowired private ObjectMapper objectMapper;
+
+    private Student student;
+    private Wallet wallet;
+    private Stop fromStop;
+    private Stop toStop;
+    private String jwt;
+
+    @BeforeEach
+    void setUp() {
+        tripRepository.deleteAll();
+        studentRepository.deleteAll();
+        stopRepository.deleteAll();
+
+        // Let Student cascade-save the Wallet via CascadeType.ALL
+        student  = studentRepository.save(
+                new Student(null, "Test Student", "test@university.edu", "password", Role.STUDENT,
+                        new Wallet(null, 500)));
+        wallet   = student.getWallet();
+        fromStop = stopRepository.save(new Stop(null, "Campus Gate", 12.9716, 77.5946));
+        toStop   = stopRepository.save(new Stop(null, "Library",     12.9352, 77.6245));
+        jwt      = jwtUtil.generateToken(student.getEmail(), student.getRole().name());
+    }
+
+    @AfterEach
+    void tearDown() {
+        tripRepository.deleteAll();
+        studentRepository.deleteAll();
+        stopRepository.deleteAll();
+    }
+
+    // ── booking ───────────────────────────────────────────────────────────────
+
+    @Test
+    void bookTrip_success_returnsBookingResultAndDebitsWallet() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/trips/book")
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId",  student.getId().toString())
+                        .param("fromStopId", fromStop.getId().toString())
+                        .param("toStopId",   toStop.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trip.status").value("BOOKED"))
+                .andExpect(jsonPath("$.finalFare").isNumber())
+                .andReturn();
+
+        int fare = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("finalFare").asInt();
+
+        Wallet updated = walletRepository.findById(wallet.getId()).orElseThrow();
+        assertThat(updated.getBalance()).isEqualTo(500 - fare);
+    }
+
+    @Test
+    void bookTrip_insufficientBalance_returnsServerError() throws Exception {
+        wallet.setBalance(0);
+        walletRepository.save(wallet);
+
+        mockMvc.perform(post("/api/trips/book")
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId",  student.getId().toString())
+                        .param("fromStopId", fromStop.getId().toString())
+                        .param("toStopId",   toStop.getId().toString()))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── cancellation ──────────────────────────────────────────────────────────
+
+    @Test
+    void bookAndCancel_withinRefundWindow_walletFullyRestored() throws Exception {
+        // Step 1: book
+        MvcResult bookResult = mockMvc.perform(post("/api/trips/book")
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId",  student.getId().toString())
+                        .param("fromStopId", fromStop.getId().toString())
+                        .param("toStopId",   toStop.getId().toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode bookJson = objectMapper.readTree(bookResult.getResponse().getContentAsString());
+        long tripId = bookJson.get("trip").get("id").asLong();
+
+        // Step 2: cancel immediately (well within the 10-minute refund window)
+        mockMvc.perform(delete("/api/trips/{tripId}/cancel", tripId)
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId", student.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        // Step 3: wallet fully restored
+        Wallet updated = walletRepository.findById(wallet.getId()).orElseThrow();
+        assertThat(updated.getBalance()).isEqualTo(500);
+    }
+
+    @Test
+    void cancelTrip_wrongStudent_returnsServerError() throws Exception {
+        // Book as the real student
+        MvcResult bookResult = mockMvc.perform(post("/api/trips/book")
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId",  student.getId().toString())
+                        .param("fromStopId", fromStop.getId().toString())
+                        .param("toStopId",   toStop.getId().toString()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        long tripId = objectMapper.readTree(bookResult.getResponse().getContentAsString())
+                .get("trip").get("id").asLong();
+
+        // Try to cancel with a different studentId
+        mockMvc.perform(delete("/api/trips/{tripId}/cancel", tripId)
+                        .header("Authorization", "Bearer " + jwt)
+                        .param("studentId", "9999"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── security ──────────────────────────────────────────────────────────────
+
+    @Test
+    void bookTrip_withoutJwt_returnsUnauthorizedOrForbidden() throws Exception {
+        mockMvc.perform(post("/api/trips/book")
+                        .param("studentId",  student.getId().toString())
+                        .param("fromStopId", fromStop.getId().toString())
+                        .param("toStopId",   toStop.getId().toString()))
+                .andExpect(status().is4xxClientError());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# ── In-memory H2 for tests (does not touch the file-based dev DB) ─────────────
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+# Disable JPA-level bean validation so test data setup works without Spring injecting validators
+spring.jpa.properties.jakarta.persistence.validation.mode=none
+
+# ── JWT ───────────────────────────────────────────────────────────────────────
+jwt.secret=test-secret-key-for-integration-tests-min-32-chars
+jwt.expiration-ms=3600000
+
+# ── Fare ──────────────────────────────────────────────────────────────────────
+fare.rate-per-km=2
+fare.peak.morning-start=7
+fare.peak.morning-end=9
+fare.peak.evening-start=17
+fare.peak.evening-end=19
+fare.peak.multiplier=1.5
+
+# ── Trip cancellation ─────────────────────────────────────────────────────────
+trip.cancellation.full-refund-minutes=10
+
+# ── University email ──────────────────────────────────────────────────────────
+university.email.domain=@university.edu
+
+# ── Caching ───────────────────────────────────────────────────────────────────
+spring.cache.type=caffeine
+cache.ttl-seconds=300
+spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=${cache.ttl-seconds}s


### PR DESCRIPTION
## What
Adds @SpringBootTest integration tests covering the full HTTP booking flow
against a real in-memory H2 database.

## Setup
- `src/test/resources/application.properties` — overrides to use
  `jdbc:h2:mem:testdb` with `ddl-auto=create-drop` so tests never touch
  the dev file DB; JPA-level bean validation disabled (tested via HTTP layer)
- `@BeforeEach` / `@AfterEach` clean the DB so tests are fully isolated

## Tests (5)
| Test | Verifies |
|---|---|
| `bookTrip_success` | 200 OK, wallet debited by exact fare |
| `bookTrip_insufficientBalance` | 400 Bad Request (GlobalExceptionHandler) |
| `bookAndCancel_withinRefundWindow` | status=CANCELLED, wallet fully restored |
| `cancelTrip_wrongStudent` | 400 Bad Request |
| `bookTrip_withoutJwt` | 4xx (security block) |

Closes #21
